### PR TITLE
only 2 players can play others can watch

### DIFF
--- a/TicTacToe/MultiplayerTicTacToe/server.ts
+++ b/TicTacToe/MultiplayerTicTacToe/server.ts
@@ -206,7 +206,22 @@ app.post("/game/join", (req, res) => {
         return res.status(404).send("Game not found");
     }
 
-    games[id].player2 = player2Name
+    if (game.player1 === player2Name) {
+
+        res.json({ game });
+
+    }
+
+    if (games[id].player2 === "") {
+
+        games[id].player2 = player2Name
+
+    }
+    else {
+
+        //make it so 3rd partys - cant watch games?
+
+    }
 
 
 
@@ -260,7 +275,6 @@ app.post("/game/:id/move", (req, res) => {
         }
 
     }
-
 
 
     const output = checkWinState(game.board);

--- a/TicTacToe/MultiplayerTicTacToe/src/pages/lobby.tsx
+++ b/TicTacToe/MultiplayerTicTacToe/src/pages/lobby.tsx
@@ -135,7 +135,7 @@ function Lobby() {
                         joinAGame(game?.id, playerName);
                       }}
                     >
-                      {"Join Game with:" + game.player1}
+                      {"Join Game with:" + game?.player1}
                     </button>
                   </Link>
                 </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 46022dbece8adc2bb966251aaf38878ea2792482  | 
|--------|--------|

### Summary:
Restrict game joining to two players and update lobby UI accordingly.

**Key points**:
- Updated `TicTacToe/MultiplayerTicTacToe/server.ts` to restrict game joining to two players.
- Modified `/game/join` endpoint to check if `player2` is already assigned.
- Added condition to prevent third-party players from joining as `player2`.
- Updated `TicTacToe/MultiplayerTicTacToe/src/pages/lobby.tsx` to handle the updated join game logic.
- Changed `joinAGame` button text to handle potential null values for `player1`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->