### PR TITLE
fixed UI and modal to reflect names

### DIFF
--- a/TicTacToe/MultiplayerTicTacToe/server.ts
+++ b/TicTacToe/MultiplayerTicTacToe/server.ts
@@ -286,11 +286,11 @@ app.post("/game/:id/move", (req, res) => {
     if (game.winnerOutput.winningOutcome === "WIN") {
         if (game.winPiece === "X") {
 
-            game.winPlayer = "Player 1"
+            game.winPlayer = game.player1
 
         }
         else {
-            game.winPlayer = "Player 2"
+            game.winPlayer = game.player2
 
         }
 

--- a/TicTacToe/MultiplayerTicTacToe/src/App.tsx
+++ b/TicTacToe/MultiplayerTicTacToe/src/App.tsx
@@ -250,7 +250,7 @@ function App() {
               id="XWinButton"
               disabled={hasWon}
             >
-              X Won: {numXWins}
+              {game?.player1} Won: {numXWins}
             </button>
             <button
               className="btn m-2 bg-gray-200 hover:bg-gray-200 disabled:bg-gray-200 btn-lg w-44  text-black disabled:text-black "
@@ -264,7 +264,7 @@ function App() {
               id="OWinButton"
               disabled={hasWon}
             >
-              O Won: {numOWins}
+              {game?.player2} Won: {numOWins}
             </button>
           </section>
           <div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 224bda6ea7b6cbfb17a46b6b54215cfe2ff13bbd  | 
|--------|--------|

### Summary:
Updated UI and modal to display actual player names instead of generic labels.

**Key points**:
- Updated `TicTacToe/MultiplayerTicTacToe/server.ts` to set `game.winPlayer` to `game.player1` or `game.player2` instead of 'Player 1' or 'Player 2'.
- Modified `TicTacToe/MultiplayerTicTacToe/src/App.tsx` to display `game.player1` and `game.player2` names in the UI buttons and winner modal.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->